### PR TITLE
added CleanDirectory helper method to retrieve count of files deleted

### DIFF
--- a/src/FileIO.cpp
+++ b/src/FileIO.cpp
@@ -344,12 +344,11 @@ namespace FileIO {
    * @param removeDirectory, whether or not the start directory should be removed
    *  @return how many entities that were not removed. I.e. a successfull remove of all would have zero entities left
    */ 
-   Result<bool> CleanDirectory(const std::string & directory, const bool removeDirectory){
+   Result<bool> CleanDirectory(const std::string & directory, const bool removeDirectory, size_t& filesRemoved){
       std::string report;
       bool noFailures = true;
 
       std::vector<std::string> foundDirectories;
-      size_t filesRemoved {0};
       auto cleanAllFiles = FileIO::CleanDirectoryOfFileContents(directory, filesRemoved, foundDirectories);
 
       if (cleanAllFiles.HasFailed()) {
@@ -380,7 +379,10 @@ namespace FileIO {
       return Result<bool> {noFailures, report};
    }
    
-
+   Result<bool> CleanDirectory(const std::string & directory, const bool removeDirectory){
+    size_t filesRemoved {0};
+    return CleanDirectory(directory, removeDirectory, filesRemoved);
+   }
 /**
     * Remove directories at the given paths
     * @return whether or not all the operations were successful

--- a/src/FileIO.h
+++ b/src/FileIO.h
@@ -37,6 +37,7 @@ namespace FileIO {
    bool DoesDirectoryHaveContent(const std::string& pathToDirectory) ;
    
    Result<bool> CleanDirectoryOfFileContents(const std::string& location, size_t& filesRemoved, std::vector<std::string>& foundDirectories);
+   Result<bool> CleanDirectory(const std::string & directory, const bool removeDirectory, size_t& filesRemoved);
    Result<bool> CleanDirectory(const std::string& directory, const bool removeDirectory);
    Result<bool> RemoveEmptyDirectories(const std::vector<std::string>& fullPathDirectories);
    

--- a/src/FileSystemWalker.cpp
+++ b/src/FileSystemWalker.cpp
@@ -56,10 +56,32 @@ bool FileSystemWalker::IsValid() const {
  * the directory tree is exhausted and there are no more entries to find
  * @result Result<int> with traversal status and any possible error messages
  *
+ * Some Useful FTSENT Flags
+ * FTS_D      A directory being visited in preorder.
+ *
+ * FTS_DC     A directory that causes a cycle in the tree.
+ *            (The fts_cycle field of the FTSENT structure
+ *            will be filled in as well.)
+ *
+ * FTS_DNR    A directory which cannot be read.  This is an
+ *            error return, and the fts_errno field will be
+ *            set to indicate what caused the error.
+ *
+ * FTS_DOT    A file named "."  or ".."  which was not
+ *            specified as a filename to fts_open() (see
+ *            FTS_SEEDOT).
+ *
+ * FTS_DP     A directory being visited in postorder.  The
+ *            contents of the FTSENT structure will be
+ *            unchanged from when it was returned in
+ *            preorder, that is, with the fts_info field
+ *            set to FTS_D.
+ *
+ * FTS_F      A regular file.
  *
  * Example usage:
    @verbatim
-  // Example of how to count all file system entities from a given path
+ // Example of how to count all file system entities from a given path
  // The saved results is saved INSIDE the given FTSENT handler
   void SomeFunc() {
     size_t entityCounter;

--- a/test/ToolsTestFileIO.cpp
+++ b/test/ToolsTestFileIO.cpp
@@ -556,6 +556,19 @@ TEST_F(TestFileIO, CleanDirectory__NoDirectory__ExpectFailure) {
    EXPECT_TRUE(result3.HasFailed());
 }
 
+TEST_F(TestFileIO, CleanDirectory__CountFilesDeleted) {
+   std::vector<std::string> newDirectories;
+   size_t removedFiles{0};  
+
+   EXPECT_EQ(removedFiles, 0);   
+   
+   CreateFile(mTestDirectory, "some_file1");  
+   CreateFile(mTestDirectory, "some_file2");  
+   EXPECT_TRUE(FileIO::CleanDirectory(mTestDirectory, true, removedFiles).result);
+   FileIO::SetInterruptFlag(); 
+   EXPECT_EQ(removedFiles, 2); 
+}
+
 TEST_F(TestFileIO, CleanDirectoryOfFilesAndDirectories) {
    const std::string baseDir = CreateSubDirectory("base");
    ASSERT_TRUE(FileIO::DoesDirectoryExist(baseDir));


### PR DESCRIPTION
* We needed to be able to access the number of files removed by CleanDirectory, but without having to change everywhere it's used.  This seemed like the easiest solution.
* also added comments to FileSystemWalker on the request of @KjellKod 